### PR TITLE
Use HTTPS for repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hapi/cryptiles",
   "description": "General purpose crypto utilities",
   "version": "6.0.3",
-  "repository": "git://github.com/hapijs/cryptiles",
+  "repository": "https://github.com/hapijs/cryptiles",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {


### PR DESCRIPTION
## Summary\n- update the package repository URL to use HTTPS instead of the legacy git protocol\n\n## Validation\n- git diff --check\n- node -e 'JSON.parse(require("fs").readFileSync("package.json","utf8"))'